### PR TITLE
Fix paths

### DIFF
--- a/Assets/Widget - Faarikaal Dark.sublime-settings
+++ b/Assets/Widget - Faarikaal Dark.sublime-settings
@@ -1,4 +1,4 @@
 {
-	"color_scheme": "Packages/faarikaal/Assets/Widget - Faarikaal Dark.stTheme",
+	"color_scheme": "Packages/Theme - Faarikaal/Assets/Widget - Faarikaal Dark.stTheme",
 	"draw_shadows": false
 }

--- a/Faarikaal Dark.sublime-theme
+++ b/Faarikaal Dark.sublime-theme
@@ -9,7 +9,7 @@
         "layer0.opacity": 1.0,
         "layer0.inner_margin": [0, 0, 0, 0],
         "layer1.opacity": 1.0,
-        "layer1.texture": "faarikaal/assets/tabset.png",// THESE TWO
+        "layer1.texture": "Theme - Faarikaal/Assets/tabset.png",// THESE TWO
         "content_margin": [-4, 0, -4, 0],               // ARE CONNECTED (1-0)
         "tab_overlap": 5,
         "tab_width": 180,
@@ -70,7 +70,7 @@
     {
         "class": "tab_close_button",
         "content_margin": [0, 0],
-        "layer0.texture": "faarikaal/assets/tabs/tab-close-inactive.png",
+        "layer0.texture": "Theme - Faarikaal/Assets/tabs/tab-close-inactive.png",
         "layer0.opacity": 0.0, // 0.4
         "layer0.inner_margin": 0
     },
@@ -82,20 +82,20 @@
     {
         "class": "tab_close_button",
         "parents": [{"class": "tab_control", "attributes": ["hover"]}],
-        "layer0.texture": "faarikaal/assets/tabs/tab-close.png",
+        "layer0.texture": "Theme - Faarikaal/Assets/tabs/tab-close.png",
         "layer0.opacity": 0.6
     },
     {
         "class": "tab_close_button",
         "parents": [{"class": "tab_control", "attributes": ["selected"]}],
-        "layer0.texture": "faarikaal/assets/tabs/tab-close.png",
+        "layer0.texture": "Theme - Faarikaal/Assets/tabs/tab-close.png",
         "layer0.opacity": 1.0
     },
     // Tab dirty button
     {
         "class": "tab_close_button",
         "parents": [{"class": "tab_control", "attributes": ["dirty"]}],
-        "layer0.texture": "faarikaal/assets/tabs/tab-dirty-inactive.png",
+        "layer0.texture": "Theme - Faarikaal/Assets/tabs/tab-dirty-inactive.png",
         "layer0.opacity": 0.6
     },
     {
@@ -112,7 +112,7 @@
     {
         "class": "tab_close_button",
         "parents": [{"class": "tab_control", "attributes": ["dirty", "selected"]}],
-        "layer0.texture": "faarikaal/assets/tabs/tab-dirty.png",
+        "layer0.texture": "Theme - Faarikaal/Assets/tabs/tab-dirty.png",
         "layer0.opacity": 1.0
     },
     // Tab highlight button
@@ -120,33 +120,33 @@
         "class": "tab_close_button",
         "settings": ["highlight_modified_tabs"],
         "parents": [{"class": "tab_control", "attributes": ["dirty"]}],
-        "layer0.texture": "faarikaal/assets/tabs/tab-highlight-inactive.png"
+        "layer0.texture": "Theme - Faarikaal/Assets/tabs/tab-highlight-inactive.png"
     },
     {
         "class": "tab_close_button",
         "settings": ["highlight_modified_tabs"],
         "parents": [{"class": "tab_control", "attributes": ["dirty", "hover"]}],
-        "layer0.texture": "faarikaal/assets/tabs/tab-highlight.png"
+        "layer0.texture": "Theme - Faarikaal/Assets/tabs/tab-highlight.png"
     },
     {
         "class": "tab_close_button",
         "settings": ["highlight_modified_tabs"],
         "parents": [{"class": "tab_control", "attributes": ["dirty", "selected"]}],
-        "layer0.texture": "faarikaal/assets/tabs/tab-highlight.png"
+        "layer0.texture": "Theme - Faarikaal/Assets/tabs/tab-highlight.png"
     },
     // Tab close button hover
     {
         "class": "tab_close_button",
         "settings": ["show_tab_close_buttons"],
         "attributes": ["hover"],
-        "layer0.texture": "faarikaal/assets/tabs/tab-close-hover.png"
+        "layer0.texture": "Theme - Faarikaal/Assets/tabs/tab-close-hover.png"
     },
     // Tab close button pressed
     {
         "class": "tab_close_button",
         "settings": ["show_tab_close_buttons"],
         "attributes": ["pressed"],
-        "layer0.texture": "faarikaal/assets/tabs/tab-close-pressed.png"
+        "layer0.texture": "Theme - Faarikaal/Assets/tabs/tab-close-pressed.png"
     },
 
 //
@@ -188,7 +188,7 @@
     {
         "class": "show_tabs_dropdown_button",
         "content_margin": [9, 7, 8, 6],
-        "layer0.texture": "faarikaal/assets/tabset-list.png",
+        "layer0.texture": "Theme - Faarikaal/Assets/tabset-list.png",
         "layer0.opacity": 0.5,
         "layer0.inner_margin": 0
     },
@@ -201,7 +201,7 @@
     {
         "class": "scroll_tabs_left_button",
         "content_margin": [9, 7, 8, 6],
-        "layer0.texture": "faarikaal/assets/tabset-left.png",
+        "layer0.texture": "Theme - Faarikaal/Assets/tabset-left.png",
         "layer0.opacity": 0.5,
         "layer0.inner_margin": 0
     },
@@ -214,7 +214,7 @@
     {
         "class": "scroll_tabs_right_button",
         "content_margin": [9, 7, 8, 6],
-        "layer0.texture": "faarikaal/assets/tabset-right.png",
+        "layer0.texture": "Theme - Faarikaal/Assets/tabset-right.png",
         "layer0.opacity": 0.5,
         "layer0.inner_margin": 0
     },
@@ -230,7 +230,7 @@
 
     {
         "class": "fold_button_control",
-        "layer0.texture": "faarikaal/assets/fold-closed.png",
+        "layer0.texture": "Theme - Faarikaal/Assets/fold-closed.png",
         "layer0.opacity": 0.2,
         "layer0.inner_margin": 0,
         "content_margin": [8, 8]
@@ -238,19 +238,19 @@
     {
         "class": "fold_button_control",
         "attributes": ["hover"],
-        "layer0.texture": "faarikaal/assets/fold-closed.png",
+        "layer0.texture": "Theme - Faarikaal/Assets/fold-closed.png",
         "layer0.opacity": 0.3
     },
     {
         "class": "fold_button_control",
         "attributes": ["expanded"],
-        "layer0.texture": "faarikaal/assets/fold-open.png",
+        "layer0.texture": "Theme - Faarikaal/Assets/fold-open.png",
         "layer0.opacity": 0.2
     },
     {
         "class": "fold_button_control",
         "attributes": ["expanded", "hover"],
-        "layer0.texture": "faarikaal/assets/fold-open.png",
+        "layer0.texture": "Theme - Faarikaal/Assets/fold-open.png",
         "layer0.opacity": 0.3
     },
 
@@ -261,7 +261,7 @@
     // Standard vertical scroll bar
     {
         "class": "scroll_bar_control",
-        "layer0.texture": "faarikaal/assets/standard-scrollbar-vertical.png",
+        "layer0.texture": "Theme - Faarikaal/Assets/standard-scrollbar-vertical.png",
         "layer0.opacity": 1.0,
         "layer0.inner_margin": [2, 6],
         "blur": false
@@ -270,21 +270,21 @@
     {
         "class": "scroll_bar_control",
         "attributes": ["horizontal"],
-        "layer0.texture": "faarikaal/assets/standard-scrollbar-horizontal.png",
+        "layer0.texture": "Theme - Faarikaal/Assets/standard-scrollbar-horizontal.png",
         "layer0.inner_margin": [6, 2],
         "blur": false
     },
     // Standard scroll bar corner
     {
         "class": "scroll_corner_control",
-        "layer0.texture": "faarikaal/assets/standard-scrollbar-corner.png",
+        "layer0.texture": "Theme - Faarikaal/Assets/standard-scrollbar-corner.png",
         "layer0.inner_margin": [2, 2],
         "layer0.opacity": 1.0
     },
     // Standard vertical scroll puck
     {
         "class": "puck_control",
-        "layer0.texture": "faarikaal/assets/standard-puck-vertical.png",
+        "layer0.texture": "Theme - Faarikaal/Assets/standard-puck-vertical.png",
         "layer0.opacity": 1.0,
         "layer0.inner_margin": [0, 10],
         "content_margin": [8, 12],
@@ -294,7 +294,7 @@
     {
         "class": "puck_control",
         "attributes": ["horizontal"],
-        "layer0.texture": "faarikaal/assets/standard-puck-horizontal.png",
+        "layer0.texture": "Theme - Faarikaal/Assets/standard-puck-horizontal.png",
         "layer0.inner_margin": [10, 0],
         "content_margin": [12, 8],
         "blur": false
@@ -319,7 +319,7 @@
     {
         "class": "scroll_bar_control",
         "settings": ["overlay_scroll_bars"],
-        "layer0.texture": "faarikaal/assets/overlay-scrollbar-vertical.png",
+        "layer0.texture": "Theme - Faarikaal/Assets/overlay-scrollbar-vertical.png",
         "layer0.inner_margin": [0, 5],
         "blur": true
     },
@@ -328,7 +328,7 @@
         "class": "scroll_bar_control",
         "settings": ["overlay_scroll_bars"],
         "attributes": ["horizontal"],
-        "layer0.texture": "faarikaal/assets/overlay-scrollbar-horizontal.png",
+        "layer0.texture": "Theme - Faarikaal/Assets/overlay-scrollbar-horizontal.png",
         "layer0.inner_margin": [5, 0],
         "blur": true
     },
@@ -336,7 +336,7 @@
     {
         "class": "puck_control",
         "settings": ["overlay_scroll_bars"],
-        "layer0.texture": "faarikaal/assets/overlay-puck-vertical.png",
+        "layer0.texture": "Theme - Faarikaal/Assets/overlay-puck-vertical.png",
         "layer0.inner_margin": [0, 5],
         "content_margin": [5, 20],
         "blur": true
@@ -346,7 +346,7 @@
         "class": "puck_control",
         "settings": ["overlay_scroll_bars"],
         "attributes": ["horizontal"],
-        "layer0.texture": "faarikaal/assets/overlay-puck-horizontal.png",
+        "layer0.texture": "Theme - Faarikaal/Assets/overlay-puck-horizontal.png",
         "layer0.inner_margin": [5, 0],
         "content_margin": [20, 5],
         "blur": true
@@ -356,14 +356,14 @@
         "class": "puck_control",
         "settings": ["overlay_scroll_bars"],
         "attributes": ["dark"],
-        "layer0.texture": "faarikaal/assets/overlay-dark-puck-vertical.png"
+        "layer0.texture": "Theme - Faarikaal/Assets/overlay-dark-puck-vertical.png"
     },
     // Overlay light horizontal puck (for dark content)
     {
         "class": "puck_control",
         "settings": ["overlay_scroll_bars"],
         "attributes": ["horizontal", "dark"],
-        "layer0.texture": "faarikaal/assets/overlay-dark-puck-horizontal.png"
+        "layer0.texture": "Theme - Faarikaal/Assets/overlay-dark-puck-horizontal.png"
     },
 
 //
@@ -533,7 +533,7 @@
     },
     {
         "class": "sidebar_tree",
-        "settings": ["faarikaal_hide_folds"],
+        "settings": ["Theme - Faarikaal_hide_folds"],
         "indent_offset": 0
     },
     // Sidebar rows
@@ -626,7 +626,7 @@
     // Sidebar file close
     {
         "class": "close_button",
-        "layer0.texture": "faarikaal/assets/file-close.png",
+        "layer0.texture": "Theme - Faarikaal/Assets/file-close.png",
         "layer0.opacity": 0.5, // 0.5
         "layer0.inner_margin": 0,
         "content_margin": [8, 8]
@@ -640,14 +640,14 @@
     {
         "class": "close_button",
         "attributes": ["dirty"],
-        "layer0.texture": "faarikaal/assets/file-dirty.png",
+        "layer0.texture": "Theme - Faarikaal/Assets/file-dirty.png",
         "layer0.opacity": 0.5
     },
     {
         "class": "close_button",
         "attributes": ["dirty"],
         "parents": [{"class": "tree_row", "attributes": ["selected"]}],
-        "layer0.texture": "faarikaal/assets/file-dirty.png",
+        "layer0.texture": "Theme - Faarikaal/Assets/file-dirty.png",
         "layer0.opacity": 1.0
     },
     {
@@ -669,7 +669,7 @@
     },
     {
         "class": "close_button",
-        "settings": ["faarikaal_hide_folds"],
+        "settings": ["Theme - Faarikaal_hide_folds"],
         "layer0.opacity": 0
     },
 
@@ -681,58 +681,58 @@
     {
         "class": "disclosure_button_control",
         "content_margin": [8, 8],
-        "layer0.texture": "faarikaal/assets/fold-closed.png",
+        "layer0.texture": "Theme - Faarikaal/Assets/fold-closed.png",
         "layer0.opacity": 0.4, // 0.4
         "layer0.inner_margin": 0
     },
     {
         "class": "disclosure_button_control",
-        "settings": ["faarikaal_hide_folds"],
+        "settings": ["Theme - Faarikaal_hide_folds"],
         "content_margin": 0
     },
     {
         "class": "disclosure_button_control",
         "parents": [{"class": "tree_row", "attributes": ["hover"]}],
-        "layer0.texture": "faarikaal/assets/fold-closed.png",
+        "layer0.texture": "Theme - Faarikaal/Assets/fold-closed.png",
         "layer0.opacity": 0.6
     },
     {
         "class": "disclosure_button_control",
         "parents": [{"class": "tree_row", "attributes": ["selected"]}],
-        "layer0.texture": "faarikaal/assets/fold-closed.png",
+        "layer0.texture": "Theme - Faarikaal/Assets/fold-closed.png",
         "layer0.opacity": 1.0
     },
     // Sidebar group open
     {
         "class": "disclosure_button_control",
         "attributes": ["expanded"],
-        "layer0.texture": "faarikaal/assets/fold-open.png",
+        "layer0.texture": "Theme - Faarikaal/Assets/fold-open.png",
         "layer0.opacity": 0.4 // 0.4
     },
     {
         "class": "disclosure_button_control",
         "attributes": ["expanded"],
         "parents": [{"class": "tree_row", "attributes": ["hover"]}],
-        "layer0.texture": "faarikaal/assets/fold-open.png",
+        "layer0.texture": "Theme - Faarikaal/Assets/fold-open.png",
         "layer0.opacity": 0.6
     },
     {
         "class": "disclosure_button_control",
         "attributes": ["expanded"],
         "parents": [{"class": "tree_row", "attributes": ["selected"]}],
-        "layer0.texture": "faarikaal/assets/fold-open.png",
+        "layer0.texture": "Theme - Faarikaal/Assets/fold-open.png",
         "layer0.opacity": 0.4
     },
     // Sidebar folder closed
     {
         "class": "icon_folder",
-        "layer0.texture": "faarikaal/icons/folder.png",
+        "layer0.texture": "Theme - Faarikaal/icons/folder.png",
         "layer0.opacity": 0.5,
         "content_margin": [8, 8]
     },
     {
         "class": "icon_folder",
-        "settings": ["faarikaal_hide_icons"],
+        "settings": ["Theme - Faarikaal_hide_icons"],
         "content_margin": 0
     },
     {
@@ -749,12 +749,12 @@
     {
         "class": "icon_folder",
         "parents": [{"class": "tree_row", "attributes": ["expanded"]}],
-        "layer0.texture": "faarikaal/icons/folder_open.png"
+        "layer0.texture": "Theme - Faarikaal/icons/folder_open.png"
     },
     {
         "class": "icon_folder",
         "parents": [{"class": "tree_row", "attributes": ["expanded"]}],
-        "settings": ["faarikaal_hide_icons"],
+        "settings": ["Theme - Faarikaal_hide_icons"],
         "content_margin": 0
     },
     {
@@ -765,7 +765,7 @@
     /*{
         "class": "icon_folder",
         "parents": [{"class": "tree_row", "attributes": ["expanded", "selected"]}],
-        "layer0.texture": "faarikaal/icons/folder_open-selected.png"
+        "layer0.texture": "Theme - Faarikaal/icons/folder_open-selected.png"
     },*/
     // Sidebar folder loading
     {
@@ -774,14 +774,14 @@
         {
             "keyframes":
             [
-                "faarikaal/assets/spinner/spinner7.png",
-                "faarikaal/assets/spinner/spinner6.png",
-                "faarikaal/assets/spinner/spinner5.png",
-                "faarikaal/assets/spinner/spinner4.png",
-                "faarikaal/assets/spinner/spinner3.png",
-                "faarikaal/assets/spinner/spinner2.png",
-                "faarikaal/assets/spinner/spinner1.png",
-                "faarikaal/assets/spinner/spinner.png"
+                "Theme - Faarikaal/Assets/spinner/spinner7.png",
+                "Theme - Faarikaal/Assets/spinner/spinner6.png",
+                "Theme - Faarikaal/Assets/spinner/spinner5.png",
+                "Theme - Faarikaal/Assets/spinner/spinner4.png",
+                "Theme - Faarikaal/Assets/spinner/spinner3.png",
+                "Theme - Faarikaal/Assets/spinner/spinner2.png",
+                "Theme - Faarikaal/Assets/spinner/spinner1.png",
+                "Theme - Faarikaal/Assets/spinner/spinner.png"
             ],
             "loop": true,
             "frame_time": 0.075,
@@ -808,7 +808,7 @@
     },
     {
         "class": "icon_file_type",
-        "settings": ["faarikaal_hide_icons"],
+        "settings": ["Theme - Faarikaal_hide_icons"],
         "content_margin": 0
     },
 
@@ -849,7 +849,7 @@
     {
         "class": "dropdown_button_control",
         "content_margin": [8, 8],
-        "layer0.texture": "faarikaal/assets/text-field-list.png",
+        "layer0.texture": "Theme - Faarikaal/Assets/text-field-list.png",
         "layer0.tint": [255, 255, 255],
         "layer0.opacity": 0.1,
         "layer0.inner_margin": [4, 4]
@@ -857,7 +857,7 @@
     {
         "class": "dropdown_button_control",
         "attributes": ["hover"],
-        "layer0.texture": "faarikaal/assets/text-field-list.png",
+        "layer0.texture": "Theme - Faarikaal/Assets/text-field-list.png",
         //"layer0.tint": [22, 22, 29],
         "layer0.opacity": 0.2
     },
@@ -877,7 +877,7 @@
     // Quick panel background
     {
         "class": "overlay_control",
-        "settings": ["!faarikaal_retina_fix"],
+        "settings": ["!Theme - Faarikaal_retina_fix"],
         "layer0.tint": [0, 0, 0],
         "layer0.inner_margin": [12, 6, 12, 15],
         "layer0.opacity": 1.0,
@@ -889,7 +889,7 @@
     // Quick panel background (Retina fix)
     {
         "class": "overlay_control",
-        "settings": ["faarikaal_retina_fix"],
+        "settings": ["Theme - Faarikaal_retina_fix"],
         "layer0.tint": [0, 0, 0],
         "layer0.opacity": 1.0,
         "content_margin": [6, 8, 6, 6]
@@ -1046,7 +1046,7 @@
         "layer0.tint": [58, 22, 29],
         "layer0.opacity": 0.0,
         "layer1.inner_margin": [-100, -100, -100, -100], // w00t
-        "layer1.texture": "faarikaal/assets/panel-close.png",
+        "layer1.texture": "Theme - Faarikaal/Assets/panel-close.png",
         "layer1.opacity": 0.4,
         "content_margin": 0 // [8, 12, 8, 13]
     },
@@ -1055,14 +1055,14 @@
         "attributes": ["hover"],
         "layer0.tint": [22, 22, 29],
         "layer0.opacity": 0.0,
-        "layer1.texture": "faarikaal/assets/panel-close.png",
+        "layer1.texture": "Theme - Faarikaal/Assets/panel-close.png",
         "layer1.opacity": 0.6
     },
     {
         "class": "panel_close_button",
         "attributes": ["pressed"],
         "layer0.tint": [0, 0, 0],
-        "layer1.texture": "faarikaal/assets/panel-close-pressed.png",
+        "layer1.texture": "Theme - Faarikaal/Assets/panel-close-pressed.png",
         "Layer1.opacity": 1.0
     },
 
@@ -1073,7 +1073,7 @@
     // Regex search button
     {
         "class": "icon_regex",
-        "layer0.texture": "faarikaal/assets/icons/icon-regex.png",
+        "layer0.texture": "Theme - Faarikaal/Assets/icons/icon-regex.png",
         "layer0.opacity": 0.1,
         "content_margin": [9, 9]
     },
@@ -1085,7 +1085,7 @@
     // Case sensitive search button
     {
         "class": "icon_case",
-        "layer0.texture": "faarikaal/assets/icons/icon-case.png",
+        "layer0.texture": "Theme - Faarikaal/Assets/icons/icon-case.png",
         "layer0.opacity": 0.1,
         "content_margin": [9, 9]
     },
@@ -1097,7 +1097,7 @@
     // Match whole word search button
     {
         "class": "icon_whole_word",
-        "layer0.texture": "faarikaal/assets/icons/icon-word.png",
+        "layer0.texture": "Theme - Faarikaal/Assets/icons/icon-word.png",
         "layer0.opacity": 0.1,
         "content_margin": [9, 9]
     },
@@ -1114,7 +1114,7 @@
     // Show search context button
     {
         "class": "icon_context",
-        "layer0.texture": "faarikaal/assets/icons/icon-context.png",
+        "layer0.texture": "Theme - Faarikaal/Assets/icons/icon-context.png",
         "layer0.opacity": 0.1,
         "content_margin": [9, 9]
     },
@@ -1126,7 +1126,7 @@
     // Use search buffer
     {
         "class": "icon_use_buffer",
-        "layer0.texture": "faarikaal/assets/icons/icon-buffer.png",
+        "layer0.texture": "Theme - Faarikaal/Assets/icons/icon-buffer.png",
         "layer0.opacity": 0.1,
         "content_margin": [9, 9]
     },
@@ -1143,7 +1143,7 @@
     // Reverse search direction button
     {
         "class": "icon_reverse",
-        "layer0.texture": "faarikaal/assets/icons/icon-reverse.png",
+        "layer0.texture": "Theme - Faarikaal/Assets/icons/icon-reverse.png",
         "layer0.opacity": 0.1,
         "content_margin": [9, 9]
     },
@@ -1155,7 +1155,7 @@
     // Search wrap button
     {
         "class": "icon_wrap",
-        "layer0.texture": "faarikaal/assets/icons/icon-wrap.png",
+        "layer0.texture": "Theme - Faarikaal/Assets/icons/icon-wrap.png",
         "layer0.opacity": 0.1,
         "content_margin": [9, 9]
     },
@@ -1167,7 +1167,7 @@
     // Search in selection button
     {
         "class": "icon_in_selection",
-        "layer0.texture": "faarikaal/assets/icons/icon-selection.png",
+        "layer0.texture": "Theme - Faarikaal/Assets/icons/icon-selection.png",
         "layer0.opacity": 0.1,
         "content_margin": [9, 9]
     },
@@ -1184,7 +1184,7 @@
     // Preserve case button
     {
         "class": "icon_preserve_case",
-        "layer0.texture": "faarikaal/assets/icons/icon-preserve.png",
+        "layer0.texture": "Theme - Faarikaal/Assets/icons/icon-preserve.png",
         "layer0.opacity": 0.1,
         "content_margin": [9, 9]
     },
@@ -1201,7 +1201,7 @@
     // Highlight results button
     {
         "class": "icon_highlight",
-        "layer0.texture": "faarikaal/assets/icons/icon-highlight.png",
+        "layer0.texture": "Theme - Faarikaal/Assets/icons/icon-highlight.png",
         "layer0.opacity": 0.1,
         "content_margin": [9, 9]
     },


### PR DESCRIPTION
There is currently an issue with this theme when you install it from Package Control.

<img width="1280" alt="screen shot 2015-12-02 at 9 27 41 am" src="https://cloud.githubusercontent.com/assets/5678694/11533524/3492efb4-98d8-11e5-86c9-9097dff77c0b.png">

This is because when you install the package through Package Control, it gets installed under the folder name `Theme - Faarikaal`, so all the paths to your icons and assets were messing it up. This pull request should fix this issue, and you will probably want to push it to Package Control asap.
